### PR TITLE
[Make]会員noマイページ詳細、編集、退会確認画面の作成

### DIFF
--- a/app/controllers/public/members/sessions_controller.rb
+++ b/app/controllers/public/members/sessions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Public::Members::SessionsController < Devise::SessionsController
-  # before_action :configure_sign_in_params, only: [:create]
+  before_action :member_state, only: [:create]
 
   # GET /resource/sign_in
   # def new
@@ -30,5 +30,18 @@ class Public::Members::SessionsController < Devise::SessionsController
 
   def after_sign_out_path_for(resource)
     new_member_session_path
+  end
+
+  protected
+
+  def member_state
+    @member = Member.find_by(email: params[:member][:email])
+      if @member.blank?
+        flash[:alert] = "必須項目を入力してください。"
+        redirect_to new_member_session_path
+      elsif @member.valid_password?(params[:member][:password]) && @member.is_delete == true
+        flash[:alert] = "退会済みの為、再登録が必要です。"
+        redirect_to new_member_session_path
+      end
   end
 end

--- a/app/controllers/public/members_controller.rb
+++ b/app/controllers/public/members_controller.rb
@@ -8,15 +8,29 @@ class Public::MembersController < ApplicationController
 
   def edit
     @member = Member.find(params[:id])
+      unless @member == current_member #現在の会員以外はマイページ編集不可
+      redirect_to member_path(current_member)
+      end
   end
 
   def update
-    @member = Member.find(params[:id])
-    @member = Member.update
-    redirect_to member_path(@member.id)
+    @member = Member.find(params[:id]) #今回は会員idがあるので、current_memberではない
+    if @member.update(member_params)
+      redirect_to member_path(@member.id)
+    else
+      render :edit
+    end
   end
 
   def confirm
+    @member = current_member
+  end
+
+  def withdraw
+    @member = current_member　#退会するのは現在の会員以外ないので、current_userでok
+    @member.update(is_delete: true)
+    reset_session
+    redirect_to root_path
   end
 
   private
@@ -26,6 +40,6 @@ class Public::MembersController < ApplicationController
   end
 
   def member_params
-    params.require(:member).permit(:profile_image, :name, :user_name, :telephone_number, :email, :introduction)
+    params.require(:member).permit(:profile_image, :name, :user_name, :telephone_number, :email, :introduction, :is_deleted)
   end
 end

--- a/app/controllers/public/trainers/sessions_controller.rb
+++ b/app/controllers/public/trainers/sessions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Public::Trainers::SessionsController < Devise::SessionsController
-  # before_action :configure_sign_in_params, only: [:create]
+  before_action :trainer_state, only: [:create]
 
   # GET /resource/sign_in
   # def new
@@ -30,5 +30,18 @@ class Public::Trainers::SessionsController < Devise::SessionsController
 
   def after_sign_out_path_for(resource)
     new_trainer_session_path
+  end
+
+  private
+
+  def trainer_state
+    @trainer = Trainer.find_by(email: params[:trainer][:email])
+      if @trainer.blank?
+        flash[:alert] = "必須項目を入力してください。"
+        redirect_to new_trainer_session_path
+      elsif @trainer.valid_password?(params[:trainer][:password]) && @trainer.is_delete == true
+        flash[:alert] = "退会済みの為、再登録が必要です。"
+        redirect_to new_trainer_session_path
+      end
   end
 end

--- a/app/controllers/public/trainers_controller.rb
+++ b/app/controllers/public/trainers_controller.rb
@@ -1,24 +1,42 @@
 class Public::TrainersController < ApplicationController
   before_action :authenticated_any
-  
+
   def show
     @trainer = Trainer.find(params[:id])
     @posts = @trainer.posts
   end
 
   def edit
+   @trainer = Trainer.find(params[:id])
+  end
+
+  def update
+    @trainer = Trainer.find(params[:id])
+    if @trainer.update(trainer_params)
+      redirect_to trainer_path(@trainer.id)
+    else
+      render :edit
+    end
   end
 
   def confirm
+    @trainer = current_member
+  end
+
+  def withdraw
+    @trainer = Trainer.find(params[:id])
+    @trainer.update(is_delete: true)
+    reset_session
+    redirect_to root_path
   end
 
   private
-  
+
   def authenticated_any
     member_signed_in? || trainer_signed_in? #いずれかログインしている場合にビューに遷移可能
   end
 
   def trainer_params
-    params.require(:trainer).permit(:profile_image, :name, :user_name, :telephone_number, :email, :introduction)
+    params.require(:trainer).permit(:profile_image, :name, :user_name, :telephone_number, :email, :introduction, :is_deleted)
   end
 end

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,8 +1,9 @@
 <p>
-  <%= image_tag 'no_image.jpg' %>
   <% if @post.member_id.present? %>      <!--投稿の投稿主が会員場合-->
+    <%= image_tag @post.member.get_profile_image(100,100) %>
     <%= @post.member.user_name %>
   <% elsif @post.trainer_id.present? %>  <!--投稿の投稿主がトレーナー場合-->
+    <%= image_tag @post.trainer.get_profile_image(100,100) %>
     <%= @post.trainer.user_name %>
   <% end %>
 </p>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,10 +1,11 @@
 <% @posts.each do |post| %>
 <div>
   <p>
-    <%= image_tag 'no_image.jpg' %>
     <% if post.member_id.present? %>      <!--投稿の投稿主が会員場合-->
+    　<%= image_tag post.member.get_profile_image(100,100) %>
     　<%= post.member.user_name %>
     <% elsif post.trainer_id.present? %>  <!--投稿の投稿主がトレーナー場合-->
+      <%= image_tag post.trainer.get_profile_image(100,100) %>
       <%= post.trainer.user_name %>
     <% end %>
   </p>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,9 +1,10 @@
 <div>
   <p>
-    <%= image_tag 'no_image.jpg' %>
     <% if @post.member_id.present? %>      <!--投稿の投稿主が会員場合-->
+      <%= image_tag @post.member.get_profile_image(100,100) %>
     　<%= @post.member.user_name %>
     <% elsif @post.trainer_id.present? %>  <!--投稿の投稿主がトレーナー場合-->
+      <%= image_tag @post.trainer.get_profile_image(100,100) %>
       <%= @post.trainer.user_name %>
     <% end %>
   </p>
@@ -35,12 +36,12 @@
   <p>コメント件数：<%= @post.post_comments.count %></p>
     <% @post.post_comments.each do |post_comment| %>
       <% unless post_comment.member.nil? # nilでない場合、コメントに紐づいたメンバーの情報を引っ張る %>
-        <p><%= image_tag post_comment.member.get_profile_image(50,50) %></p>
+        <p><%= image_tag post_comment.member.get_profile_image(100,100) %></p>
         <%= post_comment.member.user_name %>
       <% end %>
 
       <% unless post_comment.trainer.nil? # nilでない場合、コメントに紐づいたトレーナーの情報を引っ張る %>
-        <p><%= image_tag post_comment.trainer.get_profile_image(50,50) %></p>
+        <p><%= image_tag post_comment.trainer.get_profile_image(100,100) %></p>
         <%= post_comment.trainer.user_name %>
       <% end %>
 

--- a/app/views/public/members/confirm.html.erb
+++ b/app/views/public/members/confirm.html.erb
@@ -1,2 +1,11 @@
-<h1>Public::Members#confirm</h1>
-<p>Find me in app/views/public/members/confirm.html.erb</p>
+<div>
+    <div>
+      アカウントを削除すると全ての登録情報が消去されます。</br>
+      退会される場合は退会するをクリックしてください
+    </div>
+
+    <div>
+      <%= link_to "マイページへ戻る", member_path(@member.id) %>
+      <%= link_to "退会する", members_withdraw_path, method: :patch, "data-confirm" => "本当に退会しますか？" %>
+    </div>
+</div>

--- a/app/views/public/members/edit.html.erb
+++ b/app/views/public/members/edit.html.erb
@@ -1,2 +1,0 @@
-<h1>Public::Members#edit</h1>
-<p>Find me in app/views/public/members/edit.html.erb</p>

--- a/app/views/public/members/sessions/new.html.erb
+++ b/app/views/public/members/sessions/new.html.erb
@@ -1,5 +1,7 @@
 <h2>Log in</h2>
 
+<%= flash[:alert] %>
+
 <%= form_with model: @member, url: member_session_path do |f| %>
   <div class="field">
     <%= f.label :email %><br />

--- a/app/views/public/members/show.html.erb
+++ b/app/views/public/members/show.html.erb
@@ -3,7 +3,8 @@
   <%= @member.user_name %>
 
 
-  <%= @member.posts.count %>
+  <p>投稿数 <%= @member.posts.count %></P>
+  <p>氏名 <%= @member.name %></p>
 
   <% if @member == current_member %>
   <%= link_to "編集", edit_member_path(@member) %>

--- a/app/views/public/trainers/confirm.html.erb
+++ b/app/views/public/trainers/confirm.html.erb
@@ -1,2 +1,11 @@
-<h1>Public::Trainers#confirm</h1>
-<p>Find me in app/views/public/trainers/confirm.html.erb</p>
+<div>
+    <div>
+      アカウントを削除すると全ての登録情報が消去されます。</br>
+      退会される場合は退会するをクリックしてください
+    </div>
+
+    <div>
+      <%= link_to "マイページへ戻る", trainer_path(@trainer.id) %>
+      <%= link_to "退会する", trainers_withdraw_path, method: :patch, "data-confirm" => "本当に退会しますか？" %>
+    </div>
+</div>

--- a/app/views/public/trainers/edit.html.erb
+++ b/app/views/public/trainers/edit.html.erb
@@ -1,2 +1,17 @@
-<h1>Public::Trainers#edit</h1>
-<p>Find me in app/views/public/trainers/edit.html.erb</p>
+<h3>会員情報編集</h3>
+<%= form_with model: @trainer do |f| %>
+  <label for="inputImage">アイコン画像</label>
+  <%= f.file_field :profile_image, placeholder: "アイコン画像", accept: "image/*" %>
+  <label for="inputName">氏名</label>
+  <%= f.text_field :name, autofocus: true, placeholder:"名前"%>
+  <label>ユーザーネーム</label>
+  <%= f.text_field :user_name, autofocus: true, placeholder:"ユーザーネーム"%>
+  <label>電話番号</label>
+  <%= f.text_field :telephone_number %>
+  <label>メールアドレス</label>
+  <%= f.text_field :email %>
+  <label>自己紹介</label>
+  <%= f.text_area :introduction %>
+  <%= f.submit "変更を保存" %>
+  <%= link_to "退会する", trainers_confirm_path, method: :post %>
+<% end %>

--- a/app/views/public/trainers/sessions/new.html.erb
+++ b/app/views/public/trainers/sessions/new.html.erb
@@ -1,5 +1,7 @@
 <h2>Log in</h2>
 
+<%= flash[:alert] %>
+
 <%= form_with model: @trainer, url: trainer_session_path do |f| %>
   <div class="field">
     <%= f.label :email %><br />

--- a/app/views/public/trainers/show.html.erb
+++ b/app/views/public/trainers/show.html.erb
@@ -3,7 +3,8 @@
   <%= @trainer.user_name %>
 
 
-  <%= @trainer.posts.count %>
+  <p>投稿数 <%= @trainer.posts.count %></P>
+  <p>氏名 <%= @trainer.name %></p>
 
   <% if @trainer == current_trainer %>
     <%= link_to "編集", edit_trainer_path(@trainer) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,13 +27,13 @@ Rails.application.routes.draw do
       root to: "members/sessions#new"
     end
 
-    post "/members/confirm" => "members#confirm"
     patch "/members/withdraw" => "members#withdraw"
-
-    post "/trainers/confirm" => "trainers#confirm"
     patch "/trainers/withdraw" => "trainers#withdraw"
+    post "/members/confirm" => "members#confirm"
+    post "/trainers/confirm" => "trainers#confirm"
     resources :members, only:[:show, :edit, :update]
     resources :trainers, only:[:show, :edit, :update]
+
   end
 
 #管理者側ののルーティング設定


### PR DESCRIPTION
会員のマイページ画面、編集、退会確認画面を作成。
ルーティングの修正(並び替え)、sessionコントローラへの退会済みユーザーのログイン停止を設定。