### PR TITLE
[Fix]サブスク登録数を制限

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -26,6 +26,9 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
     @post_comment = PostComment.new
     PostLike.find_by(id: params[:post_like_id])&.update(is_read: true) if @post.member == current_member || @post.trainer == current_trainer
+    PostComment.find_by(id: params[:post_comment_id])&.update(is_read: true) if @post.member == current_member || @post.trainer == current_trainer
+    Relationship.find_by(id: params[:relationship_id])&.update(is_read: true) if @relationship.member == current_member || @relationship.trainer == current_trainer
+    Subscription.find_by(id: params[:subscription_id])&.update(is_read: true) if @subscription.member == current_member || @subscription.trainer == current_trainer
     redirect_to posts_path, notice: 'この記事は参照できません。' if @post.enable_post? #削除されたユーザーの投稿詳細を非公開
   end
 

--- a/app/controllers/public/members_controller.rb
+++ b/app/controllers/public/members_controller.rb
@@ -4,6 +4,7 @@ class Public::MembersController < ApplicationController
   def show
     @member = Member.find(params[:id])
     @posts = @member.posts
+    @subscription = @member.subscription
   end
 
   def edit
@@ -37,11 +38,17 @@ class Public::MembersController < ApplicationController
     @member = Member.find(params[:id]) #会員のidデータの取得
     @likes = PostLike.where(member_id: @member.id) #上記該当する会員のいいねのレコードを代入
   end
-  
+
   def new_post_likes
     @member = Member.find(params[:id])
     @post_likes = @member.new_liked
     render 'public/shared/new_post_likes'
+  end
+
+  def new_post_comments
+    @member = Member.find(params[:id])
+    @post_comments = @member.new_commented
+    render 'public/shared/new_post_comments'
   end
 
   private
@@ -51,6 +58,6 @@ class Public::MembersController < ApplicationController
   end
 
   def member_params
-    params.require(:member).permit(:profile_image, :name, :user_name, :telephone_number, :email, :introduction, :is_deleted)
+    params.require(:member).permit(:profile_image, :name, :user_name, :telephone_number, :email, :introduction, :is_deleted, :subscription_id)
   end
 end

--- a/app/controllers/public/trainers_controller.rb
+++ b/app/controllers/public/trainers_controller.rb
@@ -37,12 +37,25 @@ class Public::TrainersController < ApplicationController
     @trainer = Trainer.find(params[:id]) #トレーナーのidを取得
     @likes = PostLike.where(trainer_id: @trainer.id) ##上記該当するトレーナーのいいねのレコードを代入
   end
-  
+
   def new_post_likes
     @trainer = Trainer.find(params[:id])
     @post_likes = @trainer.new_liked
     render 'public/shared/new_post_likes'
   end
+
+  def new_post_comments
+    @trainer = Trainer.find(params[:id])
+    @post_comments = @trainer.new_commented
+    render 'public/shared/new_post_comments'
+  end
+  
+  def new_subscriptions
+    @trainer = Trainer.find(params[:id])
+    @subscriptions = @trainer.new_subscribed
+    render 'public/shared/new_subscriptions'
+  end
+  
 
   private
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -34,7 +34,7 @@ class SubscriptionsController < ApplicationController
 
   def show
     if member_signed_in?
-      @subscription = current_member.subscriptions.find(params[:id])
+      @subscription = current_member.subscription
     end
   end
 
@@ -57,7 +57,4 @@ class SubscriptionsController < ApplicationController
     params.require(:subscription).permit(:period, :payment_id, :subscription_plan_id, :trainer_id)
   end
 
-  def create_notifications
-   Notification.create!(subject: self, member_id: subscription.member.id, trainer_id: subscription.trainer.id, action_type: Notification.action_types[:subscribed_you])
-  end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -8,17 +8,20 @@ class Member < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :post_comments, dependent: :destroy
   has_many :post_likes, dependent: :destroy
-  has_many :subscriptions, dependent: :destroy
+  has_one :subscription, dependent: :destroy #サブスクは1つのみ登録可能
   #has_many :relationships, class_name: "Relationship", foreign_key: "follower_id" #同じモデル名でややこしいので、名前だけ変更
   #has_many :reverse_of_relationships, class_name: "Relationship", foreign_key: "followed_id" #同じモデル名でややこしいので、名前だけ変更
   #has_many :followings, through: :relationships, source: :followed #フォロー・フォロワーの表示するためRelationshipモデルから参照
   #has_many :followers, through: :reverse_of_relationships, source: :follower
-  
+  has_one_attached :profile_image
+
   def new_liked
     PostLike.new_likes.joins(:post).distinct.where('post.member_id': self.id)
   end
 
-  has_one_attached :profile_image
+  def new_commented
+    PostComment.new_comments.joins(:post).distinct.where('post.member_id': self.id)
+  end
 
   def get_profile_image(width, height)
       unless profile_image.attached?

--- a/app/models/post_comment.rb
+++ b/app/models/post_comment.rb
@@ -2,7 +2,8 @@ class PostComment < ApplicationRecord
   belongs_to :member, optional: :true #ログインしていなくても投稿出来るようにする
   belongs_to :trainer, optional: :true #ログインしていなくても投稿出来るようにする
   belongs_to :post
-  has_one :notification, as: :subject, dependent: :destroy
+
+  scope :new_comments, -> { where(is_read: false) } #複数のクエリをまとめる。未読のコメントを呼ぶメソッド。
 
   def required_either_member_or_trainer
     # 演算子 ^ で排他的論理和（XOR）にしています

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,3 +1,4 @@
 class Relationship < ApplicationRecord
   has_one :notification, as: :subject, dependent: :destroy
+  scope :new_relationships, -> { where(is_read: false) } #複数のクエリをまとめる。未読のサブスク登録を呼ぶメソッド。
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -3,8 +3,8 @@ class Subscription < ApplicationRecord
   belongs_to :trainer, optional: :true #ログインしていなくても投稿出来るようにする
   belongs_to :subscription_plan
   belongs_to :payment
-  has_one :notification, as: :subject, dependent: :destroy
   validate :required_either_member_or_trainer
+  scope :new_subscriptions, -> { where(is_read: false) } #複数のクエリをまとめる。未読のサブスク登録を呼ぶメソッド。
 
   def required_either_member_or_trainer
     # 演算子 ^ で排他的論理和（XOR）にしています
@@ -16,4 +16,5 @@ class Subscription < ApplicationRecord
   def subtotal
     (subscription_plan.price * period)
   end
+
 end

--- a/app/models/subscription_plan.rb
+++ b/app/models/subscription_plan.rb
@@ -1,4 +1,3 @@
 class SubscriptionPlan < ApplicationRecord
   has_many :subscription
-  has_one :notification, as: :subject, dependent: :destory
 end

--- a/app/models/trainer.rb
+++ b/app/models/trainer.rb
@@ -16,12 +16,16 @@ class Trainer < ApplicationRecord
   has_one_attached :profile_image
 
   def new_liked
-    PostLike.new_likes.joins(:post).distinct.where('post.trainer_id': self.id)
+    PostLike.new_likes.joins(:post).distinct.where('post.trainer_id': self.id) #ここのselfはtrainer自身
   end
-  
-  # def new_subscriptions
-  #   Subscription.new_subs.where(teainer_id: seld.id)
-  # end
+
+  def new_commented
+    PostComment.new_comments.joins(:post).distinct.where('post.trainer_id': self.id)
+  end
+
+  def new_subscribed
+    Subscription.new_subscriptions.where(trainer_id: self.id)
+  end
 
   def get_profile_image(width, height)
       unless profile_image.attached?

--- a/app/views/public/members/show.html.erb
+++ b/app/views/public/members/show.html.erb
@@ -28,6 +28,10 @@
       <%= link_to "フォローする", member_relationships_path(@member.id), method: :post %>
     <% end %>
   <% end %>
+
+  <% if member_signed_in? && current_member == @member %>
+    <div><%= link_to "サブスク詳細", subscription_path %></div>
+  <% end %>
 </div>
 
 <% @posts.each do |post| %>

--- a/app/views/public/shared/new_post_comments.html.erb
+++ b/app/views/public/shared/new_post_comments.html.erb
@@ -1,0 +1,6 @@
+<% @post_comments.each do |post_comment| %>
+  <ul>
+    <li><%= post_comment.post.description %></li>
+    <li><%= link_to "show", post_path(post_comment.post, post_comment_id: post_comment.id) %></li>
+  </ul>
+<% end %>

--- a/app/views/public/shared/new_post_likes.html.erb
+++ b/app/views/public/shared/new_post_likes.html.erb
@@ -1,4 +1,3 @@
-
 <% @post_likes.each do |post_like| %>
   <ul>
     <li><%= post_like.post.description %></li>

--- a/app/views/public/shared/new_subscription.html.erb
+++ b/app/views/public/shared/new_subscription.html.erb
@@ -1,0 +1,7 @@
+<% @subscriptions.each do |subscription| %>
+  <ul>
+    <li><%= subscription.member.name %></li>
+    <li><%= subscription.subscription_plan.plan %></li>
+    <li><%= link_to "show", subscription_path(subscription.id) %></li>
+  </ul>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get "/subscriptions/:trainer_id/new" => "subscriptions#new", as: "subscriptions_new"
   post "/subscriptions/confirm" => "subscriptions#confirm"
   get 'searches' => 'searches#index' #検索はネストせず単一で作成
+  get "/subscription" => "subscriptions#show"
   resources :subscriptions, only:[:create, :index, :show, :edit, :update, :destroy]
   resources :posts do
     resources :post_comments, only: [:create, :destroy]
@@ -41,6 +42,7 @@ Rails.application.routes.draw do
       member do
         get :post_likes
         get :new_post_likes
+        get :new_post_comments
       end
     end
     resources :trainers, only:[:show, :edit, :update] do
@@ -50,6 +52,8 @@ Rails.application.routes.draw do
       member do
         get :post_likes
         get :new_post_likes
+        get :new_post_comments
+        get :new_subscriptions
       end
     end
   end

--- a/db/migrate/20221028112801_add_is_read_to_post_comment.rb
+++ b/db/migrate/20221028112801_add_is_read_to_post_comment.rb
@@ -1,0 +1,5 @@
+class AddIsReadToPostComment < ActiveRecord::Migration[6.1]
+  def change
+    add_column :post_comments, :is_read, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20221028135727_add_is_read_to_subscriptions.rb
+++ b/db/migrate/20221028135727_add_is_read_to_subscriptions.rb
@@ -1,0 +1,5 @@
+class AddIsReadToSubscriptions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :subscriptions, :is_read, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_25_120512) do
+ActiveRecord::Schema.define(version: 2022_10_28_135727) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -82,6 +82,7 @@ ActiveRecord::Schema.define(version: 2022_10_25_120512) do
     t.integer "post_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "is_read", default: false, null: false
   end
 
   create_table "post_likes", force: :cascade do |t|
@@ -127,6 +128,7 @@ ActiveRecord::Schema.define(version: 2022_10_25_120512) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "period"
     t.integer "payment_id"
+    t.boolean "is_read", default: false, null: false
   end
 
   create_table "trainers", force: :cascade do |t|


### PR DESCRIPTION
会員のサブスク登録数を1つに制限。
モデルでhas_manyをhas_oneに変更した。