### PR TITLE
[Fix]フォロー機能のパス修正

### DIFF
--- a/app/controllers/public/relationships_controller.rb
+++ b/app/controllers/public/relationships_controller.rb
@@ -1,17 +1,18 @@
 class Public::RelationshipsController < ApplicationController
 
   def create
-    if current_member
-      if params[:target].to_i == 0
-        current_member.follow(params[:trainer_id], params[:target] )
-      else
-        current_member.follow(params[:trainer_id], params[:target] )
+    if current_member #現在の会員の場合
+      if params[:target].to_i == 0 #ターゲットがトレーナーの場合
+        current_member.follow(params[:trainer_id], params[:target] ) #会員がトレーナーをフォロー
+      else #ターゲットがトレーナー以外の場合
+      #byebug
+        current_member.follow(params[:member_id], params[:target] ) #会員が会員をフォロー
       end
-    else
-      if params[:target].to_i == 0
-        current_trainer.follow(params[:trainer_id], params[:target] )
-      else
-        current_trainer.follow(params[:trainer_id], params[:target] )
+    else #現在の会員以外の場合
+      if params[:target].to_i == 0 #ターゲットがトレーナーの場合
+        current_trainer.follow(params[:trainer_id], params[:target] ) #トレーナーがトレーナーをフォロー
+      else #ターゲットがトレーナー以外の場合
+        current_trainer.follow(params[:member_id], params[:target] ) #トレーナーが会員をフォロー
       end
     end
     redirect_to request.referer
@@ -22,13 +23,13 @@ class Public::RelationshipsController < ApplicationController
       if params[:target].to_i == 0
         current_member.unfollow(params[:trainer_id], params[:target] )
       else
-        current_member.unfollow(params[:trainer_id], params[:target] )
+        current_member.unfollow(params[:member_id], params[:target] )
       end
     else
       if params[:target].to_i == 0
         current_trainer.unfollow(params[:trainer_id], params[:target] )
       else
-        current_trainer.unfollow(params[:trainer_id], params[:target] )
+        current_trainer.unfollow(params[:member_id], params[:target] )
       end
     end
     redirect_to request.referer

--- a/app/views/public/members/show.html.erb
+++ b/app/views/public/members/show.html.erb
@@ -38,9 +38,9 @@
     <% if current_member %>
       <% if current_member != @member %>
         <% if current_member.following?(@member, 1 ) %>
-          <%= link_to "フォロー外す", trainer_relationships_path(@member.id, target: 1), method: :delete %>
+          <%= link_to "フォロー外す", member_relationships_path(@member.id, target: 1), method: :delete %>
         <% else %>
-          <%= link_to "フォローする", trainer_relationships_path(@member.id, target: 1), method: :post %>
+          <%= link_to "フォローする", member_relationships_path(@member.id, target: 1), method: :post %>
         <% end %>
       <% end %>
     <% else %>

--- a/app/views/public/trainers/show.html.erb
+++ b/app/views/public/trainers/show.html.erb
@@ -31,9 +31,9 @@
       <% end %>
     <% else %>
       <% if current_member.following?(@trainer, 1) %>
-        <%= link_to "フォロー外す", trainer_relationships_path(@trainer.id, target: 1), method: :delete %>
+        <%= link_to "フォロー外す", member_relationships_path(@trainer.id, target: 1), method: :delete %>
       <% else %>
-        <%= link_to "フォローする", trainer_relationships_path(@trainer.id, target: 1), method: :post %>
+        <%= link_to "フォローする", member_relationships_path(@trainer.id, target: 1), method: :post %>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
会員及びトレーナーのビュー及びコントローラに設定されているパスを変更
これはフォロー機能のルーティングを分けてしまったため、弊害で生じている。