### PR TITLE
[Fix]フォロー機能の修正

### DIFF
--- a/app/controllers/public/members_controller.rb
+++ b/app/controllers/public/members_controller.rb
@@ -40,6 +40,16 @@ class Public::MembersController < ApplicationController
     @likes = PostLike.where(member_id: @member.id) #上記該当する会員のいいねのレコードを代入
   end
 
+  def followings #フォロー一覧ページ用
+    @member = Member.find(params[:member_id])
+    @users = @member.get_following_users
+  end
+
+  def followers
+    @member = Member.find(params[:member_id])
+    @users = @member.get_followed_users
+  end
+
   # def new_post_likes
   #   @member = Member.find(params[:id])
   #   @post_likes = @member.new_liked

--- a/app/controllers/public/relationships_controller.rb
+++ b/app/controllers/public/relationships_controller.rb
@@ -5,7 +5,6 @@ class Public::RelationshipsController < ApplicationController
       if params[:target].to_i == 0 #ターゲットがトレーナーの場合
         current_member.follow(params[:trainer_id], params[:target] ) #会員がトレーナーをフォロー
       else #ターゲットがトレーナー以外の場合
-      #byebug
         current_member.follow(params[:member_id], params[:target] ) #会員が会員をフォロー
       end
     else #現在の会員以外の場合
@@ -33,26 +32,6 @@ class Public::RelationshipsController < ApplicationController
       end
     end
     redirect_to request.referer
-  end
-
-  def followings #フォロー一覧ページ用
-    if member_signed_in?
-      member = Member.find(params[:member_id])
-      @members = member.followings
-    elsif trainer_signed_in
-      trainer = Trainer.find(params[:trainer_id])
-      @trainers = trainer.followings
-    end
-  end
-
-  def followers #フォロワー一覧ページ用
-    if member_signed_in
-      member = Member.find(params[:member_id])
-      @members = member.followers
-    elsif trainer_signed_in
-      trainer = Trainer.find(params[:trainer_id])
-      @trainers = trainer.followers
-    end
   end
 
   private

--- a/app/controllers/public/trainers_controller.rb
+++ b/app/controllers/public/trainers_controller.rb
@@ -39,6 +39,16 @@ class Public::TrainersController < ApplicationController
     @trainer = Trainer.find(params[:id]) #トレーナーのidを取得
     @likes = PostLike.where(trainer_id: @trainer.id) ##上記該当するトレーナーのいいねのレコードを代入
   end
+  
+  def followings #フォロー一覧ページ用
+    @trainer = Trainer.find(params[:trainer_id])
+    @users = @trainer.get_following_users
+  end
+
+  def followers
+    @trainer = Trainer.find(params[:trainer_id])
+    @users = @trainer.get_followed_users
+  end
 
   # def new_post_likes
   #   @trainer = Trainer.find(params[:id])

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -67,6 +67,10 @@ class Member < ApplicationRecord
   def get_following_trainers
     Trainer.find(Relationship.where(follower_id: self.id, followed_type: USER_TYPE[:"Trainer"]).pluck('followed_id'))
   end
+  
+  def get_following_users
+    get_following_members + get_following_trainers
+  end
 
   def follower_count
     get_followed_members.count + get_followed_trainers.count
@@ -78,6 +82,10 @@ class Member < ApplicationRecord
 
   def get_followed_trainers
     Trainer.find(Relationship.where(followed_id: self.id, followed_type: USER_TYPE[:"Trainer"]).pluck('follower_id'))
+  end
+  
+  def get_followed_users
+    get_followed_members + get_followed_trainers
   end
 
   # def get_follower_members #自分にフォローしている会員を取得。リレーションが使えないため、メソッドで定義。

--- a/app/models/trainer.rb
+++ b/app/models/trainer.rb
@@ -15,7 +15,7 @@ class Trainer < ApplicationRecord
   #has_many :followings, through: :relationships, source: :followed
   #has_many :followers, through: :reverse_of_relationships, source: :follower
   has_one_attached :profile_image
-  
+
   validates :name, presence: true
   validates :user_name, presence: true
   validates :email, uniqueness: true, presence: true
@@ -72,6 +72,10 @@ class Trainer < ApplicationRecord
     Trainer.find(Relationship.where(follower_id: self.id, followed_type: USER_TYPE[:"Trainer"]).pluck('followed_id'))
   end
 
+  def get_following_users
+    get_following_members + get_following_trainers
+  end
+
   def follower_count
     get_followed_members.count + get_followed_trainers.count
   end
@@ -82,6 +86,10 @@ class Trainer < ApplicationRecord
 
   def get_followed_trainers
     Trainer.find(Relationship.where(followed_id: self.id, followed_type: USER_TYPE[:"Trainer"]).pluck('follower_id'))
+  end
+
+  def get_followed_users
+    get_followed_members + get_followed_trainers
   end
 
   def self.search(keyword)

--- a/app/views/public/members/followers.html.erb
+++ b/app/views/public/members/followers.html.erb
@@ -1,0 +1,18 @@
+<% @users.each do |user| %>
+  <table>
+    <thead>
+      <tr>
+        <th>名前</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><%= user.name %></td>
+        <td>フォロー数: <%= user.following_count %></td>
+        <td>フォロワー数: <%= user.follower_count %></td>
+      </tr>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/public/members/followings.html.erb
+++ b/app/views/public/members/followings.html.erb
@@ -1,0 +1,18 @@
+<% @users.each do |user| %>
+  <table>
+    <thead>
+      <tr>
+        <th>名前</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><%= user.name %></td>
+        <td>フォロー数: <%= user.following_count %></td>
+        <td>フォロワー数: <%= user.follower_count %></td>
+      </tr>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/public/members/show.html.erb
+++ b/app/views/public/members/show.html.erb
@@ -4,11 +4,11 @@
       <div class="pt-4 ml-3"><%= @member.user_name %></div>
       <div class="pt-4 col-sm-2">
         <%= @member.follower_count %>
-        <div id="padding">フォロワー</div>
+        <div id="padding"><%= link_to "フォロワー", member_followers_path(member_id: @member) %></div>
       </div>
       <div class="pt-4 col-sm-2">
         <%= @member.following_count %>
-        <div id="padding">フォロー中</div>
+        <div id="padding"><%= link_to "フォロー中", member_followings_path(member_id: @member) %></div>
       </div>
       <div class="pt-4 col-sm-2">
         <%= @member.posts.count %>
@@ -38,16 +38,16 @@
     <% if current_member %>
       <% if current_member != @member %>
         <% if current_member.following?(@member, 1 ) %>
-          <%= link_to "フォロー外す", member_relationships_path(@member.id, target: 1), method: :delete, class: "btn btn-primary" %>
+          <%= link_to "フォロー外す", member_relationships_path(@member.id, target: 1), method: :delete, class: "btn btn-primary mr-5" %>
         <% else %>
-          <%= link_to "フォローする", member_relationships_path(@member.id, target: 1), method: :post, class: "btn btn-primary" %>
+          <%= link_to "フォローする", member_relationships_path(@member.id, target: 1), method: :post, class: "btn btn-primary mr-5" %>
         <% end %>
       <% end %>
     <% else %>
       <% if current_trainer.following?(@member, 0) %>
-        <%= link_to "フォロー外す", trainer_relationships_path(@member.id, target: 0), method: :delete, class: "btn btn-primary" %>
+        <%= link_to "フォロー外す", trainer_relationships_path(@member.id, target: 0), method: :delete, class: "btn btn-primary mr-5" %>
       <% else %>
-        <%= link_to "フォローする", trainer_relationships_path(@member.id, target: 0), method: :post, class: "btn btn-primary" %>
+        <%= link_to "フォローする", trainer_relationships_path(@member.id, target: 0), method: :post, class: "btn btn-primary mr-5" %>
       <% end %>
     <% end %>
 

--- a/app/views/public/trainers/followers.html.erb
+++ b/app/views/public/trainers/followers.html.erb
@@ -1,0 +1,18 @@
+<% @users.each do |user| %>
+  <table>
+    <thead>
+      <tr>
+        <th>名前</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><%= user.name %></td>
+        <td>フォロー数: <%= user.following_count %></td>
+        <td>フォロワー数: <%= user.follower_count %></td>
+      </tr>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/public/trainers/followings.html.erb
+++ b/app/views/public/trainers/followings.html.erb
@@ -1,0 +1,18 @@
+<% @users.each do |user| %>
+  <table>
+    <thead>
+      <tr>
+        <th>名前</th>
+        <th></th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><%= user.name %></td>
+        <td>フォロー数: <%= user.following_count %></td>
+        <td>フォロワー数: <%= user.follower_count %></td>
+      </tr>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/public/trainers/show.html.erb
+++ b/app/views/public/trainers/show.html.erb
@@ -4,11 +4,11 @@
       <div class="pt-4 ml-3"><%= @trainer.user_name %></div>
       <div class="pt-4 col-sm-2">
         <%= @trainer.follower_count %>
-        <div id="padding">フォロワー</div>
+        <div id="padding"><%= link_to "フォロワー", trainer_followers_path(trainer_id: @trainer) %></div>
       </div>
       <div class="pt-4 col-sm-2">
         <%= @trainer.following_count %>
-        <div id="padding">フォロー中</div>
+        <div id="padding"><%= link_to "フォロー中", trainer_followings_path(trainer_id: @trainer) %></div>
       </div>
       <div class="pt-4 col-sm-2">
         <%= @trainer.posts.count %>
@@ -38,16 +38,16 @@
     <% if current_trainer %>
       <% if current_trainer != @trainer %>
         <% if current_trainer.following?(@trainer, 0 ) %>
-          <%= link_to "フォロー外す", trainer_relationships_path(@trainer.id, target: 0), method: :delete, class: "btn btn-primary" %>
+          <%= link_to "フォロー外す", trainer_relationships_path(@trainer.id, target: 0), method: :delete, class: "btn btn-primary mr-5" %>
         <% else %>
-          <%= link_to "フォローする", trainer_relationships_path(@trainer.id, target: 0), method: :post, class: "btn btn-primary" %>
+          <%= link_to "フォローする", trainer_relationships_path(@trainer.id, target: 0), method: :post, class: "btn btn-primary mr-5" %>
         <% end %>
       <% end %>
     <% else %>
       <% if current_member.following?(@trainer, 1) %>
-        <%= link_to "フォロー外す", member_relationships_path(@trainer.id, target: 1), method: :delete, class: "btn btn-primary" %>
+        <%= link_to "フォロー外す", member_relationships_path(@trainer.id, target: 1), method: :delete, class: "btn btn-primary mr-5" %>
       <% else %>
-        <%= link_to "フォローする", member_relationships_path(@trainer.id, target: 1), method: :post, class: "btn btn-primary" %>
+        <%= link_to "フォローする", member_relationships_path(@trainer.id, target: 1), method: :post, class: "btn btn-primary mr-5" %>
       <% end %>
     <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,8 +38,8 @@ Rails.application.routes.draw do
     get "/trainers/confirm" => "trainers#confirm"
     resources :members, only:[:show, :edit, :update] do
       resource :relationships, only: [:create, :destroy]
-      get "followings" => "relationships#followings", as: "followings"
-      get "followers" => "relationships#create", as: "followers"
+      get "followings" => "members#followings", as: "followings"
+      get "followers" => "members#followers", as: "followers"
       member do
         get :post_likes
         get :new_notifications
@@ -47,8 +47,8 @@ Rails.application.routes.draw do
     end
     resources :trainers, only:[:show, :edit, :update] do
       resource :relationships, only: [:create, :destroy]
-      get "followings" => "relationships#followings", as: "followings"
-      get "followers" => "relationships#create", as: "followers"
+      get "followings" => "trainers#followings", as: "followings"
+      get "followers" => "trainers#followers", as: "followers"
       member do
         get :post_likes
         get :new_notifications


### PR DESCRIPTION
フォロー機能のコントローラ及びルーティングを修正した。
(1)一覧表示を見る際にルーティングがcreateを通っていた。一覧表示にcreateアクションはいらないので確認するとルーティングが間違っていた。
(2)トレーナーから会員、会員からトレーナーの一覧が見れなかった。relationshipコントローラに無理にif文でわけて定義していたので、member及びtrainerでそれぞれ定義した。ルーティングも併せて変更。
